### PR TITLE
4.4 の端末でテーマを切り替えると画面遷移が無限ループする

### DIFF
--- a/Sample/android_color_definition/app/src/main/java/com/github/mag0716/android_color_definition/MainActivity.java
+++ b/Sample/android_color_definition/app/src/main/java/com/github/mag0716/android_color_definition/MainActivity.java
@@ -41,17 +41,17 @@ public class MainActivity extends AppCompatActivity {
     private ViewPager viewPager;
     private TabLayout tab;
     private FloatingActionButton fab;
-
-    private int currentThemeIndex = 0;
+    ;
+    private String currentTheme = "AppTheme";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         if (getIntent().hasExtra(KEY_THEME)) {
-            currentThemeIndex = getIntent().getIntExtra(KEY_THEME, 0);
+            currentTheme = getIntent().getStringExtra(KEY_THEME);
         }
-        setTheme(getResources().getIdentifier(getResources().getStringArray(R.array.spinner_items)[currentThemeIndex], "style", getPackageName()));
+        setTheme(getResources().getIdentifier(currentTheme, "style", getPackageName()));
 
         setContentView(R.layout.activity_main);
 
@@ -108,17 +108,8 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        // Handle action bar item clicks here. The action bar will
-        // automatically handle clicks on the Home/Up button, so long
-        // as you specify a parent activity in AndroidManifest.xml.
-        int id = item.getItemId();
-
-        //noinspection SimplifiableIfStatement
-        if (id == R.id.action_settings) {
-            return true;
-        }
-
-        return super.onOptionsItemSelected(item);
+        changeTheme((String) item.getTitle());
+        return true;
     }
 
     public void onClick(View view) {
@@ -147,9 +138,9 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
-    public void changeTheme(int themeIndex) {
+    public void changeTheme(String theme) {
         final Intent intent = new Intent(this, MainActivity.class);
-        intent.putExtra(KEY_THEME, themeIndex);
+        intent.putExtra(KEY_THEME, theme);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
         startActivity(intent);
     }
@@ -166,7 +157,7 @@ public class MainActivity extends AppCompatActivity {
 
         @Override
         public Fragment getItem(int position) {
-            return SampleFragment.newInstance(position == 0, currentThemeIndex);
+            return SampleFragment.newInstance(position == 0);
         }
 
         @Override

--- a/Sample/android_color_definition/app/src/main/java/com/github/mag0716/android_color_definition/SampleFragment.java
+++ b/Sample/android_color_definition/app/src/main/java/com/github/mag0716/android_color_definition/SampleFragment.java
@@ -8,25 +8,22 @@ import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
 
 import com.github.mag0716.android_color_definition.databinding.FragmentSampleBinding;
 
 /**
  * A simple {@link Fragment} subclass.
  */
-public class SampleFragment extends Fragment implements AdapterView.OnItemSelectedListener {
+public class SampleFragment extends Fragment {
 
     private static final String KEY_ENABLED = "enabled";
-    private static final String KEY_THEME = "theme";
 
     private boolean initialized = false;
 
-    public static SampleFragment newInstance(boolean isEnabled, int themeIndex) {
+    public static SampleFragment newInstance(boolean isEnabled) {
         SampleFragment fragment = new SampleFragment();
         Bundle bundle = new Bundle();
         bundle.putBoolean(KEY_ENABLED, isEnabled);
-        bundle.putInt(KEY_THEME, themeIndex);
         fragment.setArguments(bundle);
         return fragment;
     }
@@ -42,40 +39,21 @@ public class SampleFragment extends Fragment implements AdapterView.OnItemSelect
         final Bundle arguments = getArguments();
 
         FragmentSampleBinding binding = DataBindingUtil.inflate(inflater, R.layout.fragment_sample, container, false);
-        binding.setViewModel(new SampleViewModel(arguments.getBoolean(KEY_ENABLED), arguments.getInt(KEY_THEME, 0)));
-        binding.spinner.setOnItemSelectedListener(this);
+        binding.setViewModel(new SampleViewModel(arguments.getBoolean(KEY_ENABLED)));
         return binding.getRoot();
-    }
-
-    @Override
-    public void onItemSelected(AdapterView<?> adapterView, View view, int position, long id) {
-        if (initialized && getActivity() instanceof MainActivity) {
-            ((MainActivity) getActivity()).changeTheme(position);
-        }
-        initialized = true;
-    }
-
-    @Override
-    public void onNothingSelected(AdapterView<?> adapterView) {
-
     }
 
     public class SampleViewModel extends BaseObservable {
 
         private final boolean isEnabled;
-        private final int spinnerIndex;
 
-        SampleViewModel(boolean isEnabled, int spinnerIndex) {
+        SampleViewModel(boolean isEnabled) {
             this.isEnabled = isEnabled;
-            this.spinnerIndex = spinnerIndex;
         }
 
         public boolean isEnabled() {
             return isEnabled;
         }
 
-        public int getSpinnerIndex() {
-            return spinnerIndex;
-        }
     }
 }

--- a/Sample/android_color_definition/app/src/main/java/com/github/mag0716/android_color_definition/dialog/SimpleConfirmationDialog.java
+++ b/Sample/android_color_definition/app/src/main/java/com/github/mag0716/android_color_definition/dialog/SimpleConfirmationDialog.java
@@ -33,14 +33,14 @@ public class SimpleConfirmationDialog extends DialogFragment {
                 .setNegativeButton("Cancel", null);
 
         if (isMultipleSelectable) {
-            builder.setMultiChoiceItems(R.array.dialog_items, null, new DialogInterface.OnMultiChoiceClickListener() {
+            builder.setMultiChoiceItems(R.array.items, null, new DialogInterface.OnMultiChoiceClickListener() {
                 @Override
                 public void onClick(DialogInterface dialogInterface, int i, boolean b) {
 
                 }
             });
         } else {
-            builder.setSingleChoiceItems(R.array.dialog_items, 0, new DialogInterface.OnClickListener() {
+            builder.setSingleChoiceItems(R.array.items, 0, new DialogInterface.OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialogInterface, int i) {
                 }

--- a/Sample/android_color_definition/app/src/main/res/layout/fragment_sample.xml
+++ b/Sample/android_color_definition/app/src/main/res/layout/fragment_sample.xml
@@ -37,8 +37,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/view_margin"
                 android:enabled="@{viewModel.enabled}"
-                android:entries="@array/spinner_items"
-                android:selectedItemPosition="@{viewModel.spinnerIndex}" />
+                android:entries="@array/items" />
 
             <LinearLayout
                 android:layout_width="match_parent"

--- a/Sample/android_color_definition/app/src/main/res/menu/menu_main.xml
+++ b/Sample/android_color_definition/app/src/main/res/menu/menu_main.xml
@@ -3,8 +3,53 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="com.github.mag0716.android_color_definition.MainActivity">
     <item
-        android:id="@+id/action_settings"
+        android:id="@+id/default_theme"
         android:orderInCategory="100"
-        android:title="@string/action_settings"
+        android:title="AppTheme"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/accent"
+        android:orderInCategory="100"
+        android:title="AppTheme.CustomAccent"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/control_normal"
+        android:orderInCategory="100"
+        android:title="AppTheme.CustomControlNormal"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/control_activated"
+        android:orderInCategory="100"
+        android:title="AppTheme.CustomControlActivated"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/control_highlight"
+        android:orderInCategory="100"
+        android:title="AppTheme.CustomControlHighlight"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/button_normal"
+        android:orderInCategory="100"
+        android:title="AppTheme.CustomButtonNormal"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/control_background"
+        android:orderInCategory="100"
+        android:title="AppTheme.CustomControlBackground"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/text_color_primary"
+        android:orderInCategory="100"
+        android:title="AppTheme.TextColorPrimary"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/text_color_secondary"
+        android:orderInCategory="100"
+        android:title="AppTheme.TextColorSecondary"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/text_color_tertiary"
+        android:orderInCategory="100"
+        android:title="AppTheme.TextColorTertiary"
         app:showAsAction="never" />
 </menu>

--- a/Sample/android_color_definition/app/src/main/res/values/strings.xml
+++ b/Sample/android_color_definition/app/src/main/res/values/strings.xml
@@ -6,20 +6,7 @@
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
 
-    <string-array name="spinner_items">
-        <item>AppTheme</item>
-        <item>AppTheme.CustomAccent</item>
-        <item>AppTheme.CustomControlNormal</item>
-        <item>AppTheme.CustomControlActivated</item>
-        <item>AppTheme.CustomControlHighlight</item>
-        <item>AppTheme.CustomButtonNormal</item>
-        <item>AppTheme.CustomControlBackground</item>
-        <item>AppTheme.TextColorPrimary</item>
-        <item>AppTheme.TextColorSecondary</item>
-        <item>AppTheme.TextColorTertiary</item>
-    </string-array>
-
-    <string-array name="dialog_items">
+    <string-array name="items">
         <item>Item1</item>
         <item>Item2</item>
         <item>Item3</item>


### PR DESCRIPTION
Spinner の onItemSelected が 2回走るのが原因

```
        binding.spinner.post(new Runnable() {
            @Override
            public void run() {
                binding.spinner.setOnItemSelectedListener(SampleFragment.this);
            }
        });
```

に修正する
-> Android 8.0 だと NG

https://stackoverflow.com/questions/14560733/spinners-onitemselected-callback-called-twice-after-a-rotation-if-non-zero-posi