### PR TITLE
TextInputLayout を利用する

### DIFF
--- a/Sample/android_color_definition/app/src/main/java/com/github/mag0716/android_color_definition/MainActivity.java
+++ b/Sample/android_color_definition/app/src/main/java/com/github/mag0716/android_color_definition/MainActivity.java
@@ -41,7 +41,7 @@ public class MainActivity extends AppCompatActivity {
     private ViewPager viewPager;
     private TabLayout tabLayout;
     private FloatingActionButton fab;
-    ;
+
     private String currentTheme = "AppTheme";
 
     @Override
@@ -105,8 +105,8 @@ public class MainActivity extends AppCompatActivity {
             }
 
         }
-    }
 
+    }
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {

--- a/Sample/android_color_definition/app/src/main/java/com/github/mag0716/android_color_definition/SampleFragment.java
+++ b/Sample/android_color_definition/app/src/main/java/com/github/mag0716/android_color_definition/SampleFragment.java
@@ -18,7 +18,7 @@ public class SampleFragment extends Fragment {
 
     private static final String KEY_ENABLED = "enabled";
 
-    private boolean initialized = false;
+    private FragmentSampleBinding binding;
 
     public static SampleFragment newInstance(boolean isEnabled) {
         SampleFragment fragment = new SampleFragment();
@@ -38,8 +38,17 @@ public class SampleFragment extends Fragment {
                              Bundle savedInstanceState) {
         final Bundle arguments = getArguments();
 
-        FragmentSampleBinding binding = DataBindingUtil.inflate(inflater, R.layout.fragment_sample, container, false);
+        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_sample, container, false);
         binding.setViewModel(new SampleViewModel(arguments.getBoolean(KEY_ENABLED)));
+        binding.edittext1.setOnFocusChangeListener(new View.OnFocusChangeListener() {
+            @Override
+            public void onFocusChange(View view, boolean focused) {
+                binding.textInputLayout1.setErrorEnabled(!focused);
+                if (!focused) {
+                    binding.textInputLayout1.setError("Error");
+                }
+            }
+        });
         return binding.getRoot();
     }
 
@@ -54,6 +63,5 @@ public class SampleFragment extends Fragment {
         public boolean isEnabled() {
             return isEnabled;
         }
-
     }
 }

--- a/Sample/android_color_definition/app/src/main/res/layout/fragment_sample.xml
+++ b/Sample/android_color_definition/app/src/main/res/layout/fragment_sample.xml
@@ -55,6 +55,23 @@
                     android:hint="EditText" />
             </android.support.design.widget.TextInputLayout>
 
+            <android.support.design.widget.TextInputLayout
+                android:id="@+id/text_input_layout3"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:enabled="@{viewModel.enabled}"
+                app:passwordToggleEnabled="true">
+
+                <EditText
+                    android:id="@+id/edittext3"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/view_margin"
+                    android:enabled="@{viewModel.enabled}"
+                    android:hint="EditText"
+                    android:inputType="textPassword" />
+            </android.support.design.widget.TextInputLayout>
+
             <Spinner
                 android:id="@+id/spinner"
                 android:layout_width="wrap_content"

--- a/Sample/android_color_definition/app/src/main/res/layout/fragment_sample.xml
+++ b/Sample/android_color_definition/app/src/main/res/layout/fragment_sample.xml
@@ -23,13 +23,37 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <EditText
-                android:id="@+id/edittext"
+            <android.support.design.widget.TextInputLayout
+                android:id="@+id/text_input_layout1"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/view_margin"
+                android:enabled="@{viewModel.enabled}">
+
+                <EditText
+                    android:id="@+id/edittext1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/view_margin"
+                    android:enabled="@{viewModel.enabled}"
+                    android:hint="EditText" />
+            </android.support.design.widget.TextInputLayout>
+
+            <android.support.design.widget.TextInputLayout
+                android:id="@+id/text_input_layout2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
                 android:enabled="@{viewModel.enabled}"
-                android:hint="EditText" />
+                app:counterEnabled="true"
+                app:counterMaxLength="10">
+
+                <EditText
+                    android:id="@+id/edittext2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/view_margin"
+                    android:enabled="@{viewModel.enabled}"
+                    android:hint="EditText" />
+            </android.support.design.widget.TextInputLayout>
 
             <Spinner
                 android:id="@+id/spinner"


### PR DESCRIPTION
#12 のアプリに TextInputLayout を適用して
https://material.io/guidelines/components/text-fields.html
の表示を実現できないかを試す。

```
            <android.support.design.widget.TextInputLayout
                android:id="@+id/text_input_layout"
                android:layout_width="match_parent"
                android:layout_height="wrap_content"
                app:counterEnabled="true"
                app:counterMaxLength="10"
                app:errorEnabled="true">

                <EditText
                    android:id="@+id/edittext"
                    android:layout_width="match_parent"
                    android:layout_height="wrap_content"
                    android:layout_marginBottom="@dimen/view_margin"
                    android:enabled="@{viewModel.enabled}"
                    android:hint="EditText" />
            </android.support.design.widget.TextInputLayout>
```