### PR TITLE
Android Studio を 3.0 beta5 & support library アップデート

### DIFF
--- a/Sample/android_color_definition/app/build.gradle
+++ b/Sample/android_color_definition/app/build.gradle
@@ -24,11 +24,11 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:26.0.1'
-    implementation 'com.android.support:design:26.0.1'
+    implementation 'com.android.support:appcompat-v7:26.0.2'
+    implementation 'com.android.support:design:26.0.2'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
-    implementation 'com.android.support:support-v4:26.0.1'
+    implementation 'com.android.support:support-v4:26.0.2'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.0'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.0'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 }

--- a/Sample/android_color_definition/build.gradle
+++ b/Sample/android_color_definition/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta1'
+        classpath 'com.android.tools.build:gradle:3.0.0-beta5'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/Sample/android_color_definition/gradle/wrapper/gradle-wrapper.properties
+++ b/Sample/android_color_definition/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Aug 26 22:01:39 JST 2017
+#Sat Sep 09 14:55:13 JST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Android Studio 3.0 beta5 
https://androidstudio.googleblog.com/2017/09/android-studio-30-beta-5.html

support library 26.0.2 
https://developer.android.com/topic/libraries/support-library/revisions.html

にアップデート