### PR TITLE
Android Studio & support library バージョンアップ

### DIFF
--- a/Sample/android_color_definition/app/build.gradle
+++ b/Sample/android_color_definition/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
+    buildToolsVersion '26.0.2'
     defaultConfig {
         applicationId "com.github.mag0716.android_color_definition"
         minSdkVersion 19
@@ -24,10 +24,10 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:26.0.2'
-    implementation 'com.android.support:design:26.0.2'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:design:26.1.0'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
-    implementation 'com.android.support:support-v4:26.0.2'
+    implementation 'com.android.support:support-v4:26.1.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'

--- a/Sample/android_color_definition/build.gradle
+++ b/Sample/android_color_definition/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta5'
+        classpath 'com.android.tools.build:gradle:3.0.0-rc1'
         
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Android Studio 3.0 RC1
https://androidstudio.googleblog.com/2017/10/android-studio-30-rc-1-now-available.html

Support Library 26.1.0
https://developer.android.com/topic/libraries/support-library/revisions.html#26-1-0

にバージョンアップ