### PR TITLE
ktlint のフォーマットをコミット前に行う

### DIFF
--- a/LibrarySample/KtlintSample/app/build.gradle
+++ b/LibrarySample/KtlintSample/app/build.gradle
@@ -37,7 +37,7 @@ ktlint {
     version = "0.15.0"
     debug = true
     verbose = true
-    android = false
+    android = true
     reporter = ReporterType.CHECKSTYLE
-    ignoreFailures = true
+    ignoreFailures = false
 }


### PR DESCRIPTION
ktlint のフォーマットをローカルで行うように強制させることでレビュー工数を減らす