### PR TITLE
Timber 5.0.0-SNAPSHOT を試す

### DIFF
--- a/Sample/MultipleModuleSample/api/build.gradle
+++ b/Sample/MultipleModuleSample/api/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     implementation Libraries.retrofit
     implementation Libraries.retrofitMoshiConverter
     implementation Libraries.retrofitCoroutinesAdapter
+
+    implementation Libraries.timberJdk
 }
 
 sourceCompatibility = "7"

--- a/Sample/MultipleModuleSample/api/src/main/java/com/github/mag0716/api/ApiServiceModule.kt
+++ b/Sample/MultipleModuleSample/api/src/main/java/com/github/mag0716/api/ApiServiceModule.kt
@@ -5,18 +5,20 @@ import com.github.mag0716.api.response.DetailResponse
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
+import timber.log.Timber
+import timber.log.debug
 
 object ApiServiceModule {
 
     fun provide(): ApiService {
         return object : ApiService {
             override fun data() = GlobalScope.async {
-                println("data")
+                Timber.debug { "data" }
                 return@async createData()
             }
 
             override fun detail(id: Int) = GlobalScope.async {
-                println("detail($id)")
+                Timber.debug { "detail($id)" }
                 return@async createDetail(id)
             }
         }

--- a/Sample/MultipleModuleSample/app/build.gradle
+++ b/Sample/MultipleModuleSample/app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation Libraries.navigationUi
     implementation Libraries.navigationUiKtx
 
-    implementation Libraries.timber
+    implementation Libraries.timberAndroid
 
     // for multi module
     // TODO: 依存する module はなるべく少なくする。それが無理な場合は app から触れるクラスを制限する

--- a/Sample/MultipleModuleSample/app/src/main/java/com/github/mag0716/multiplemodulesample/App.kt
+++ b/Sample/MultipleModuleSample/app/src/main/java/com/github/mag0716/multiplemodulesample/App.kt
@@ -9,6 +9,7 @@ import com.github.mag0716.usercase.IGetDataDetailUseCase
 import com.github.mag0716.usercase.IGetDataListUseCase
 import com.github.mag0716.usercase.provideGetDataDetailUseCase
 import com.github.mag0716.usercase.provideGetDataListUseCase
+import timber.log.LogcatTree
 import timber.log.Timber
 
 class App : Application() {
@@ -30,6 +31,6 @@ class App : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        Timber.plant(Timber.DebugTree())
+        Timber.plant(LogcatTree("MultipleModuleSample"))
     }
 }

--- a/Sample/MultipleModuleSample/build.gradle
+++ b/Sample/MultipleModuleSample/build.gradle
@@ -22,7 +22,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
     }
 }
 

--- a/Sample/MultipleModuleSample/buildSrc/src/main/java/Dependencies.kt
+++ b/Sample/MultipleModuleSample/buildSrc/src/main/java/Dependencies.kt
@@ -31,7 +31,10 @@ object Libraries {
     val retrofit = "com.squareup.retrofit2:retrofit:2.4.0"
     val retrofitMoshiConverter = "com.squareup.retrofit2:converter-moshi:2.4.0"
     val retrofitCoroutinesAdapter = "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2"
-    val timber = "com.jakewharton.timber:timber:4.7.1"
+    val timberCommon = "com.jakewharton.timber:timber-common:5.0.0-SNAPSHOT"
+    val timberJdk = "com.jakewharton.timber:timber-jdk:5.0.0-SNAPSHOT"
+    val timberAndroid = "com.jakewharton.timber:timber-android:5.0.0-SNAPSHOT"
+
 
     // test
     val junit = "junit:junit:4.12"

--- a/Sample/MultipleModuleSample/datasource/build.gradle
+++ b/Sample/MultipleModuleSample/datasource/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation Libraries.coroutineCore
     implementation Libraries.appcompat
 
-    implementation Libraries.timber
+    implementation Libraries.timberAndroid
 
     // for multi module
     implementation project(":api")

--- a/Sample/MultipleModuleSample/datasource/src/main/java/com/github/mag0716/datasource/DataRepository.kt
+++ b/Sample/MultipleModuleSample/datasource/src/main/java/com/github/mag0716/datasource/DataRepository.kt
@@ -8,6 +8,7 @@ import com.github.mag0716.datasource.converter.toDetail
 import com.github.mag0716.datasource.model.Data
 import com.github.mag0716.datastore.model.Detail
 import timber.log.Timber
+import timber.log.debug
 
 internal class DataRepository(val apiService: ApiService) : IDataRepository {
 
@@ -19,7 +20,7 @@ internal class DataRepository(val apiService: ApiService) : IDataRepository {
     // TODO:リフレッシュ機構
 
     override suspend fun fetchDataListOrCache(): List<Data> {
-        Timber.d("fetchDataListOrCache($this) : apiService = $apiService")
+        Timber.debug { "fetchDataListOrCache($this) : apiService = $apiService" }
         if (dataListCached == null) {
             dataListCached = apiService.data().await()
         }
@@ -27,7 +28,7 @@ internal class DataRepository(val apiService: ApiService) : IDataRepository {
     }
 
     override suspend fun fetchDataDetailOrCache(id: Int): Detail {
-        Timber.d("fetchDataDetailOrCache($this) : apiService = $apiService")
+        Timber.debug { "fetchDataDetailOrCache($this) : apiService = $apiService" }
         if (detailMap.contains(id).not()) {
             val detail = apiService.detail(id).await()
             detailMap[id] = detail

--- a/Sample/MultipleModuleSample/usecase/build.gradle
+++ b/Sample/MultipleModuleSample/usecase/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
     implementation project(":datasource")
 
-    implementation Libraries.timber
+    implementation Libraries.timberAndroid
 
     // for test
     testImplementation Libraries.junit

--- a/Sample/MultipleModuleSample/usecase/src/main/java/com/github/mag0716/usercase/GetDataDetailUseCase.kt
+++ b/Sample/MultipleModuleSample/usecase/src/main/java/com/github/mag0716/usercase/GetDataDetailUseCase.kt
@@ -3,10 +3,11 @@ package com.github.mag0716.usercase
 import com.github.mag0716.datasource.IDataRepository
 import com.github.mag0716.datastore.model.Detail
 import timber.log.Timber
+import timber.log.debug
 
 internal class GetDataDetailUseCase(private val repository: IDataRepository) : IGetDataDetailUseCase {
     override suspend fun execute(id: Int): Detail {
-        Timber.d("GetDataDetailUseCase($this) : repository = $repository")
+        Timber.debug { "GetDataDetailUseCase($this) : repository = $repository" }
         return repository.fetchDataDetailOrCache(id)
     }
 }

--- a/Sample/MultipleModuleSample/usecase/src/main/java/com/github/mag0716/usercase/GetDataListUseCase.kt
+++ b/Sample/MultipleModuleSample/usecase/src/main/java/com/github/mag0716/usercase/GetDataListUseCase.kt
@@ -3,10 +3,11 @@ package com.github.mag0716.usercase
 import com.github.mag0716.datasource.IDataRepository
 import com.github.mag0716.datasource.model.Data
 import timber.log.Timber
+import timber.log.debug
 
 internal class GetDataListUseCase(private val repository: IDataRepository) : IGetDataListUseCase {
     override suspend fun execute(): List<Data> {
-        Timber.d("GetDataListUseCase($this) : repository = $repository")
+        Timber.debug { "GetDataListUseCase($this) : repository = $repository" }
         return repository.fetchDataListOrCache()
     }
 }


### PR DESCRIPTION
# 概要

java-library のモジュールで Timber 4.x を利用することはできなかったが、
5.0.0-SNAPSHOT で MPP をサポートしたので利用することができないかを試す

# 関連

#64