### PR TITLE
datasource, usecase モジュールを java-library にする

### DIFF
--- a/Sample/MultipleModuleSample/api/build.gradle
+++ b/Sample/MultipleModuleSample/api/build.gradle
@@ -13,6 +13,3 @@ dependencies {
 
     implementation Libraries.timberJdk
 }
-
-sourceCompatibility = "7"
-targetCompatibility = "7"

--- a/Sample/MultipleModuleSample/datasource/build.gradle
+++ b/Sample/MultipleModuleSample/datasource/build.gradle
@@ -1,40 +1,17 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-
-android {
-    compileSdkVersion Version.compileSdk
-    defaultConfig {
-        minSdkVersion Version.minSdk
-        targetSdkVersion Version.targetSdk
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        debug {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro', 'coroutine_proguard-rules.pro'
-        }
-        release {
-            minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro', 'coroutine_proguard-rules.pro'
-        }
-    }
-}
+apply plugin: 'java-library'
+apply plugin: 'kotlin'
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation Libraries.kotlin
     implementation Libraries.coroutineCore
-    implementation Libraries.appcompat
 
-    implementation Libraries.timberAndroid
+    implementation Libraries.timberJdk
 
     // for multi module
     implementation project(":api")
 
     // for test
     testImplementation Libraries.junit
-    androidTestImplementation Libraries.runner
-    androidTestImplementation Libraries.espresso
 }

--- a/Sample/MultipleModuleSample/usecase/build.gradle
+++ b/Sample/MultipleModuleSample/usecase/build.gradle
@@ -1,39 +1,16 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-
-android {
-    compileSdkVersion Version.compileSdk
-    defaultConfig {
-        minSdkVersion Version.minSdk
-        targetSdkVersion Version.targetSdk
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        debug {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro', 'coroutine_proguard-rules.pro'
-        }
-        release {
-            minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro', 'coroutine_proguard-rules.pro'
-        }
-    }
-}
+apply plugin: 'java-library'
+apply plugin: 'kotlin'
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation Libraries.kotlin
     implementation Libraries.coroutineCore
-    implementation Libraries.appcompat
 
     implementation project(":datasource")
 
-    implementation Libraries.timberAndroid
+    implementation Libraries.timberJdk
 
     // for test
     testImplementation Libraries.junit
-    androidTestImplementation Libraries.runner
-    androidTestImplementation Libraries.espresso
 }


### PR DESCRIPTION
## 概要

app モジュール以外は Android に依存しないようにしたいので、java-library にする。

## 関連

#64 

## 対応メモ

* 単純に java-library に変えるだけで OK
    * android 定義を削除
    * Timber は JDK 用にする