### PR TITLE
[マルチモジュール] Proguard

### DIFF
--- a/Sample/MultipleModuleSample/api/proguard-rules.pro
+++ b/Sample/MultipleModuleSample/api/proguard-rules.pro
@@ -1,0 +1,26 @@
+### OkHttp, Retrofit and Moshi
+-dontwarn okhttp3.**
+-dontwarn retrofit2.Platform$Java8
+-dontwarn okio.**
+-dontwarn javax.annotation.**
+-keepclasseswithmembers class * {
+    @retrofit2.http.* <methods>;
+}
+-keepclasseswithmembers class * {
+    @com.squareup.moshi.* <methods>;
+}
+-keep @com.squareup.moshi.JsonQualifier interface *
+-dontwarn org.jetbrains.annotations.**
+-keep class kotlin.Metadata { *; }
+-keepclassmembers class kotlin.Metadata {
+    public <methods>;
+}
+
+-keepclassmembers class * {
+    @com.squareup.moshi.FromJson <methods>;
+    @com.squareup.moshi.ToJson <methods>;
+}
+
+-keepnames @kotlin.Metadata class com.myapp.packagename.model.**
+-keep class com.github.mag0716.api.** { *; }
+-keepclassmembers class com.github.mag0716.api.** { *; }

--- a/Sample/MultipleModuleSample/app/build.gradle
+++ b/Sample/MultipleModuleSample/app/build.gradle
@@ -16,11 +16,17 @@ android {
     buildTypes {
         debug {
             minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro', 'coroutine_proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
+                    'proguard-rules.pro',
+                    'coroutine_proguard-rules.pro',
+                    '../api/proguard-rules.pro'
         }
         release {
             minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro', 'coroutine_proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
+                    'proguard-rules.pro',
+                    'coroutine_proguard-rules.pro',
+                    '../api/proguard-rules.pro'
         }
     }
 }

--- a/Sample/MultipleModuleSample/app/proguard-rules.pro
+++ b/Sample/MultipleModuleSample/app/proguard-rules.pro
@@ -12,43 +12,5 @@
 #   public *;
 #}
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
-
-### OkHttp, Retrofit and Moshi
--dontwarn okhttp3.**
--dontwarn retrofit2.Platform$Java8
--dontwarn okio.**
--dontwarn javax.annotation.**
--keepclasseswithmembers class * {
-    @retrofit2.http.* <methods>;
-}
--keepclasseswithmembers class * {
-    @com.squareup.moshi.* <methods>;
-}
--keep @com.squareup.moshi.JsonQualifier interface *
--dontwarn org.jetbrains.annotations.**
--keep class kotlin.Metadata { *; }
--keepclassmembers class kotlin.Metadata {
-    public <methods>;
-}
-
--keepclassmembers class * {
-    @com.squareup.moshi.FromJson <methods>;
-    @com.squareup.moshi.ToJson <methods>;
-}
-
--keepnames @kotlin.Metadata class com.myapp.packagename.model.**
--keep class com.github.mag0716.api.** { *; }
--keepclassmembers class com.github.mag0716.api.** { *; }
-
-### Logging
--assumenosideeffects class kotlin.io {
-     public void println(%);
-     public void println(**);
-}
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile


### PR DESCRIPTION
## 概要

マルチモジュールプロジェクトでも Proguard が可能かどうか？
-> 通常通り proguard-rules.pro に定義し、app/build.gradle で指定すれば OK
今回は OkHttp などは API でのみ依存しているので、api モジュール内で保持するようにした。

## 概要

#64

## メモ

`java-library` だと `app` 側で proguard ファイルを読み込まないといけない？
`com.android.library` だと

```
android.buildTypes.release {
    consumerProguardFiles 'proguard-rules.pro'
}
```

のようにモジュール内で完結させることができるので、悩ましい。
https://gfx.hatenablog.com/entry/2016/01/16/184846