### PR TITLE
[マルチモジュール] flavor

### DIFF
--- a/Sample/MultipleModuleSample/apidev/.gitignore
+++ b/Sample/MultipleModuleSample/apidev/.gitignore
@@ -1,0 +1,2 @@
+/build
+*.iml

--- a/Sample/MultipleModuleSample/apidev/build.gradle
+++ b/Sample/MultipleModuleSample/apidev/build.gradle
@@ -1,0 +1,7 @@
+apply plugin: 'java-library'
+apply plugin: 'kotlin'
+
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    api project(":api")
+}

--- a/Sample/MultipleModuleSample/apidev/src/main/java/com/github/mag0716/api/ApiServiceModule.kt
+++ b/Sample/MultipleModuleSample/apidev/src/main/java/com/github/mag0716/api/ApiServiceModule.kt
@@ -40,4 +40,5 @@ object ApiServiceModule {
             createdTime = System.currentTimeMillis()
         )
     }
+
 }

--- a/Sample/MultipleModuleSample/apiprod/.gitignore
+++ b/Sample/MultipleModuleSample/apiprod/.gitignore
@@ -1,0 +1,2 @@
+/build
+*.iml

--- a/Sample/MultipleModuleSample/apiprod/build.gradle
+++ b/Sample/MultipleModuleSample/apiprod/build.gradle
@@ -1,0 +1,8 @@
+apply plugin: 'java-library'
+apply plugin: 'kotlin'
+
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    api project(":api")
+}
+

--- a/Sample/MultipleModuleSample/apiprod/src/main/java/com/github/mag0716/api/ApiServiceModule.kt
+++ b/Sample/MultipleModuleSample/apiprod/src/main/java/com/github/mag0716/api/ApiServiceModule.kt
@@ -1,0 +1,17 @@
+package com.github.mag0716.api
+
+import retrofit2.Retrofit
+
+object ApiServiceModule {
+
+    fun provide(): ApiService {
+        // FIXME: 動作する API サーバの定義への対応
+        // base url をどこで定義するのか迷うところだが、
+        // API 側の仕様を全て別モジュールにしたいので、api モジュール側で定義する
+        // テスト用に増えた時などは面倒かも
+        return Retrofit.Builder()
+            .baseUrl("https://example.com/")
+            .build()
+            .create(ApiService::class.java)
+    }
+}

--- a/Sample/MultipleModuleSample/app/build.gradle
+++ b/Sample/MultipleModuleSample/app/build.gradle
@@ -13,6 +13,15 @@ android {
         versionName Version.name
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+    flavorDimensions "environment"
+    productFlavors {
+        prod {
+            dimension "environment"
+        }
+        dev {
+            dimension "environment"
+        }
+    }
     buildTypes {
         debug {
             minifyEnabled false

--- a/Sample/MultipleModuleSample/app/build.gradle
+++ b/Sample/MultipleModuleSample/app/build.gradle
@@ -59,7 +59,8 @@ dependencies {
     // TODO: 依存する module はなるべく少なくする。それが無理な場合は app から触れるクラスを制限する
     implementation project(":usecase")
     implementation project(":datasource")
-    implementation project(":api")
+    prodImplementation project(":apiprod")
+    devImplementation project(":apidev")
 
     // for test
     testImplementation Libraries.junit

--- a/Sample/MultipleModuleSample/settings.gradle
+++ b/Sample/MultipleModuleSample/settings.gradle
@@ -1,1 +1,1 @@
-include ':app', ':api', ':datasource', ':usecase'
+include ':app', ':api', ':datasource', ':usecase', ':apidev', ':apiprod'


### PR DESCRIPTION
## 概要

flavor を指定し、API サーバの URL などを切り替えるケースは多々存在するので検証。

## メモ

`com.android.library` だと、モジュール側に flavor を定義できるので便利。
`java-library` だとモジュールごと分けて、DI で切り替えるなどの一手間が必要。