### PR TITLE
touchscreenがないChrome OSデバイスが存在するので必須を解除

### DIFF
--- a/Sample/MultipleDeviceSupportSample/app/src/main/AndroidManifest.xml
+++ b/Sample/MultipleDeviceSupportSample/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.github.mag0716.multipledevicesupportsample">
 
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
+    
     <uses-permission android:name="android.permission.CAMERA" />
 
     <application


### PR DESCRIPTION
## 概要

全てのChrome OSデバイスをサポートするためにtouchscreenを必須としない。

## 関連

* #98

## 参考

https://developer.android.com/topic/arc#update_your_apps_manifest_file