### PR TITLE
[Chrome OS] onTopResumedActivityChangedサポート

### DIFF
--- a/Sample/MultipleDeviceSupportSample/app/src/main/java/com/github/mag0716/multipledevicesupportsample/ui/base/LoggingActivity.kt
+++ b/Sample/MultipleDeviceSupportSample/app/src/main/java/com/github/mag0716/multipledevicesupportsample/ui/base/LoggingActivity.kt
@@ -22,6 +22,11 @@ open class LoggingActivity : AppCompatActivity() {
         Timber.d("${this::class.java}#onResume")
     }
 
+    override fun onTopResumedActivityChanged(isTopResumedActivity: Boolean) {
+        super.onTopResumedActivityChanged(isTopResumedActivity)
+        Timber.d("${this::class.java}#onTopResumedActivityChanged $isTopResumedActivity")
+    }
+
     override fun onPause() {
         super.onPause()
         Timber.d("${this::class.java}#onPause")


### PR DESCRIPTION
## 概要

`Activity#onTopResumedActivityChanged` でのハンドリングを考慮する

### 詳細

Android 10 で `onResume`, `onPause` の動作が変わり、同時に複数のウィンドウが `RESUMED` 状態になるようになった。
(Android 9 以前では、`RESUMED` 状態になるのは1つのアプリのみで、マルチウィンドウでフォーカスを変えるたびに`onResume`, `onPause` が呼び出されていた。)

それに伴い、`onTopResumedActivityChanged` が追加され、一番上で `RESUMED` になった場合に呼ばれるようになった。
カメラなどのシステムで1つのリソースの確保などで利用することになる。

## 関連

#98

## 参考

* https://developer.android.com/reference/android/app/Activity#onTopResumedActivityChanged(boolean)
* https://developer.android.com/about/versions/10/behavior-changes-10#foldables
* https://developer.android.com/guide/topics/ui/foldables#exclusive_resources_access