### PR TITLE
[WIP] 入力変換モードを無効化

### DIFF
--- a/Sample/MultipleDeviceSupportSample/app/src/main/AndroidManifest.xml
+++ b/Sample/MultipleDeviceSupportSample/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-feature
         android:name="android.hardware.touchscreen"
         android:required="false" />
+    <uses-feature
+        android:name="android.hardware.type.pc"
+        android:required="false" />
 
     <uses-permission android:name="android.permission.CAMERA" />
 


### PR DESCRIPTION
## 概要

Chrome OS は入力変換モードがデフォルトで有効になっている。
入力変換モードとは

* トラックパッドでの2つの指でのスクロール
* マウスホイールのスクロール

など。
大抵のアプリではコードの変更無しでアプリに対応されるが、
ピンチインアクションをカスタマイズしたい場合などは無効化する必要がある。

## 参考

* https://developer.android.com/topic/arc/input-compatibility.html#input_translation_mode

## 関連

#98