### PR TITLE
ACTION_APPWIDGET_UPDATEをsendBroadcastする方法も検証

### DIFF
--- a/Sample/AppWidgetSample/app/src/main/java/com/github/mag0716/appwidgetsample/MainActivity.kt
+++ b/Sample/AppWidgetSample/app/src/main/java/com/github/mag0716/appwidgetsample/MainActivity.kt
@@ -2,6 +2,7 @@ package com.github.mag0716.appwidgetsample
 
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.widget.Button
@@ -16,7 +17,8 @@ class MainActivity : AppCompatActivity() {
     }
 
     private lateinit var checkBox: CheckBox
-    private lateinit var button: Button
+    private lateinit var button1: Button
+    private lateinit var button2: Button
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -27,22 +29,46 @@ class MainActivity : AppCompatActivity() {
         checkBox.setOnCheckedChangeListener { _, isChecked ->
             (application as App).repository.isEnabled = isChecked
         }
-        button = findViewById(R.id.button)
-        button.setOnClickListener {
+        button1 = findViewById(R.id.button1)
+        button1.setOnClickListener {
             updateWidgets()
+        }
+        button2 = findViewById(R.id.button2)
+        button2.setOnClickListener {
+            sendBroadcast()
         }
     }
 
+    // 複数回呼ぶとホームランチャーに遷移したタイミングで1度だけonDataSetChangedが呼ばれる
     private fun updateWidgets() {
         Log.d(TAG, "updateWidgets")
         val context = applicationContext
         val appWidgetManager = AppWidgetManager.getInstance(context)
         val appWidgetIds = appWidgetManager.getAppWidgetIds(
-                ComponentName(
-                        context,
-                        ListAppWidget::class.java
-                )
+            ComponentName(
+                context,
+                ListAppWidget::class.java
+            )
         )
         appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetIds, R.id.list)
+    }
+
+    // 複数回呼ぶと初回はonDataSetChangedが呼ばれる
+    // 2回目以降はonUpdateまでは呼ばれるがonDataSetChangedは呼ばれない
+    private fun sendBroadcast() {
+        Log.d(TAG, "sendBroadcast")
+        val context = applicationContext
+        val appWidgetManager = AppWidgetManager.getInstance(context)
+        val appWidgetIds = appWidgetManager.getAppWidgetIds(
+            ComponentName(
+                context,
+                ListAppWidget::class.java
+            )
+        )
+        val intent = Intent().apply {
+            action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
+            putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, appWidgetIds)
+        }
+        sendBroadcast(intent)
     }
 }

--- a/Sample/AppWidgetSample/app/src/main/res/layout/activity_main.xml
+++ b/Sample/AppWidgetSample/app/src/main/res/layout/activity_main.xml
@@ -14,9 +14,15 @@
         android:text="データ取得可能" />
 
     <Button
-        android:id="@+id/button"
+        android:id="@+id/button1"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="ウィジェット更新" />
+        android:text="ウィジェット更新\n(notifyAppWidgetViewDataChanged)" />
+
+    <Button
+        android:id="@+id/button2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="ウィジェット更新\n(sendBroadcast)" />
 
 </LinearLayout>


### PR DESCRIPTION
## 概要

#106 で `notifyAppWidgetViewDataChanged` での更新で正常に動作していたが、
`ACTION_APPWIDGET_UPDATE` だとどうなるのかを検証。

結果、`ACTION_APPWIDGET_UPDATE` だと2回目以降は `onDataSetChanged` が発生しないことが判明